### PR TITLE
Data not available to lm inside Pboot.R and Tboot.R

### DIFF
--- a/R/Pboot.R
+++ b/R/Pboot.R
@@ -52,8 +52,7 @@ Pboot <- function(model, significance=0.05,
     
     y_star = as.vector(Xbeta + t_star*error_hat/root_1_less_h)
     model_string = as.character(model$call$formula)
-    model_star = lm(formula=as.formula(paste("y_star~",
-                                             as.character(model_string[3]),sep="")))
+    model_star = lm(y_star ~ X[,-1])
     error_hat_star = as.vector(model_star$residuals)
     beta_star = as.vector(model_star$coefficients)
     matrix_beta_star[j,] = as.vector(beta_star)
@@ -70,8 +69,7 @@ Pboot <- function(model, significance=0.05,
         
         y_star_star = as.vector(Xbeta_star + t_star_star*error_hat_star/root_1_less_h)
         model_string = as.character(model$call$formula)
-        model_star_star = lm(formula=as.formula(paste("y_star_star~",
-                                                      as.character(model_string[3]),sep="")))
+        model_star_star = lm(y_star_star ~ X[,-1])
         beta_star_star = as.vector(model_star_star$coefficients)
         
         for(m in 1:number_parameters){

--- a/R/Tboot.R
+++ b/R/Tboot.R
@@ -56,8 +56,7 @@ function(model, significance=0.05, hc=4,
     
     y_star = as.vector(Xbeta + t_star*error_hat/root_1_less_h)
     model_string = as.character(model$call$formula)
-    model_star = lm(formula=as.formula(paste("y_star~",
-                    as.character(model_string[3]),sep="")))
+    model_star = lm(y_star ~ X[,-1])
     error_hat_star = as.vector(model_star$residuals)
     beta_star = as.vector(model_star$coefficients)
     standard_error_star = sqrt(diag(HC(model_star, method=hc)))
@@ -77,8 +76,7 @@ function(model, significance=0.05, hc=4,
         }else t_star_star = rnorm(length(model$fitted.values),0,1)
         y_star_star = as.vector(Xbeta_star + t_star_star*error_hat_star/root_1_less_h)
         model_string = as.character(model$call$formula)
-        model_star_star = lm(formula=as.formula(paste("y_star_star~",
-                                                as.character(model_string[3]),sep="")))
+        model_star_star = lm(y_star_star ~ X[,-1])
         beta_star_star = as.vector(model_star_star$coefficients)
         standard_error_star_star = sqrt(diag(HC(model_star_star, method=hc)))
       


### PR DESCRIPTION
Below is a reproducible example where hcci failed to find variables that are in the original model.  

> weakliem2 <- read.csv("http://www.quantoid.net/files/reg3/weakliem2.txt")
> install.packages("hcci")
> trying URL 'http://cran.rstudio.com/bin/macosx/mavericks/contrib/3.2/hcci_1.0.0.tgz'
> # Content type 'application/x-gzip' length 29169 bytes (28 KB)
> 
> downloaded 28 KB
> library(hcci)
> mod <- lm(secpay ~ gini + log(gdp), data=weakliem2)
> confint(mod)
>                    2.5 %     97.5 %
> (Intercept) -120.1930383 33.9733976
> gini          -0.5698534  0.5937271
> log(gdp)      -1.2535215 15.1376866
> Pboot(mod)
> Error in eval(expr, envir, enclos) : object 'gini' not found

I fixed lines 55 and 72 in Pboot.R as well as 59 and 79 in Tboot.R so they use the X matrix that was created to produce the y-hats as covariates rather than relying on data being available in R's search path.  
